### PR TITLE
Setup GAS classes

### DIFF
--- a/Helltech/Helltech.sln.DotSettings
+++ b/Helltech/Helltech.sln.DotSettings
@@ -1,0 +1,2 @@
+﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=helltech/@EntryIndexedValue">True</s:Boolean></wpf:ResourceDictionary>

--- a/Helltech/Helltech.uproject
+++ b/Helltech/Helltech.uproject
@@ -7,7 +7,10 @@
 		{
 			"Name": "Helltech",
 			"Type": "Runtime",
-			"LoadingPhase": "Default"
+			"LoadingPhase": "Default",
+			"AdditionalDependencies": [
+				"GameplayAbilities"
+			]
 		}
 	],
 	"Plugins": [
@@ -17,6 +20,10 @@
 			"TargetAllowList": [
 				"Editor"
 			]
+		},
+		{
+			"Name": "GameplayAbilities",
+			"Enabled": true
 		}
 	]
 }

--- a/Helltech/Source/Helltech/Abilities/HelltechAbilitySystemComponent.cpp
+++ b/Helltech/Source/Helltech/Abilities/HelltechAbilitySystemComponent.cpp
@@ -1,0 +1,26 @@
+#include "HelltechAbilitySystemComponent.h"
+#include "AbilitySystemGlobals.h"
+#include "GameplayCueManager.h"
+
+void UHelltechAbilitySystemComponent::ExecuteGameplayCueLocal(const FGameplayTag GameplayCueTag,
+                                                              const FGameplayCueParameters& GameplayCueParameters) const
+{
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(
+		GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::Executed, GameplayCueParameters);
+}
+
+void UHelltechAbilitySystemComponent::AddGameplayCueLocal(const FGameplayTag GameplayCueTag,
+                                                          const FGameplayCueParameters& GameplayCueParameters) const
+{
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(
+		GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::OnActive, GameplayCueParameters);
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(
+		GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::WhileActive, GameplayCueParameters);
+}
+
+void UHelltechAbilitySystemComponent::RemoveGameplayCueLocal(const FGameplayTag GameplayCueTag,
+                                                             const FGameplayCueParameters& GameplayCueParameters) const
+{
+	UAbilitySystemGlobals::Get().GetGameplayCueManager()->HandleGameplayCue(
+		GetOwner(), GameplayCueTag, EGameplayCueEvent::Type::Removed, GameplayCueParameters);
+}

--- a/Helltech/Source/Helltech/Abilities/HelltechAbilitySystemComponent.h
+++ b/Helltech/Source/Helltech/Abilities/HelltechAbilitySystemComponent.h
@@ -1,0 +1,29 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystemComponent.h"
+#include "HelltechAbilitySystemComponent.generated.h"
+
+/**
+ * Base Ability System Component for all characters.
+ * Tracks ability initialization and effect application state. Currently minimal, but can be extended to handle damage
+ * events, cooldown management, and other ability system interactions.
+ */
+UCLASS()
+class HELLTECH_API UHelltechAbilitySystemComponent : public UAbilitySystemComponent
+{
+	GENERATED_BODY()
+
+public:
+	UFUNCTION(BlueprintCallable, Category = "GameplayCue")
+	void ExecuteGameplayCueLocal(const FGameplayTag GameplayCueTag,
+	                             const FGameplayCueParameters& GameplayCueParameters) const;
+
+	UFUNCTION(BlueprintCallable, Category = "GameplayCue")
+	void AddGameplayCueLocal(const FGameplayTag GameplayCueTag,
+	                         const FGameplayCueParameters& GameplayCueParameters) const;
+
+	UFUNCTION(BlueprintCallable, Category = "GameplayCue")
+	void RemoveGameplayCueLocal(const FGameplayTag GameplayCueTag,
+	                            const FGameplayCueParameters& GameplayCueParameters) const;
+};

--- a/Helltech/Source/Helltech/Abilities/HelltechAttributeSet.cpp
+++ b/Helltech/Source/Helltech/Abilities/HelltechAttributeSet.cpp
@@ -1,0 +1,11 @@
+#include "HelltechAttributeSet.h"
+
+void UHelltechAttributeSet::PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue)
+{
+	Super::PreAttributeChange(Attribute, NewValue);
+
+	if (Attribute == GetMaxMoveSpeedAttribute())
+	{
+		UE_LOG(LogTemp, Warning, TEXT("Set MaxMoveSpeed attribute to: %f"), NewValue);
+	}
+}

--- a/Helltech/Source/Helltech/Abilities/HelltechAttributeSet.h
+++ b/Helltech/Source/Helltech/Abilities/HelltechAttributeSet.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "AbilitySystemComponent.h"
+#include "AttributeSet.h"
+#include "HelltechAttributeSet.generated.h"
+
+#define HELLTECH_ATTRIBUTE_ACCESSORS(ClassName, PropertyName) \
+		GAMEPLAYATTRIBUTE_PROPERTY_GETTER(ClassName, PropertyName) \
+		GAMEPLAYATTRIBUTE_VALUE_GETTER(PropertyName) \
+		GAMEPLAYATTRIBUTE_VALUE_SETTER(PropertyName) \
+		GAMEPLAYATTRIBUTE_VALUE_INITTER(PropertyName)
+
+/**
+ * Base Attribute Set class that defines core character stats.
+ * Manages character level and movement attributes with appropriate validation. Extend this class to add health,
+ * damage, experience, and any other game-specific stats.
+ */
+UCLASS()
+class HELLTECH_API UHelltechAttributeSet : public UAttributeSet
+{
+	GENERATED_BODY()
+
+public:
+	virtual void PreAttributeChange(const FGameplayAttribute& Attribute, float& NewValue) override;
+
+	UPROPERTY(BlueprintReadOnly, Category = "Movement")
+	FGameplayAttributeData MaxMoveSpeed;
+	HELLTECH_ATTRIBUTE_ACCESSORS(UHelltechAttributeSet, MaxMoveSpeed)
+};

--- a/Helltech/Source/Helltech/Abilities/HelltechGameplayAbility.cpp
+++ b/Helltech/Source/Helltech/Abilities/HelltechGameplayAbility.cpp
@@ -1,0 +1,42 @@
+#include "HelltechGameplayAbility.h"
+
+#include "Helltech.h"
+
+UHelltechGameplayAbility::UHelltechGameplayAbility(): AbilityID(ELilithAbilityID::None)
+{
+}
+
+const FGameplayTagContainer* UHelltechGameplayAbility::GetCooldownTags() const
+{
+	// Do not call Super::GetCooldownTags(), this should fully replace it.
+
+	FGameplayTagContainer* MutableTags = const_cast<FGameplayTagContainer*>(&TempCooldownTags);
+	MutableTags->Reset();
+
+	if (const FGameplayTagContainer* ParentTags = Super::GetCooldownTags())
+	{
+		MutableTags->AppendTags(*ParentTags);
+	}
+
+	MutableTags->AppendTags(CooldownTags);
+	return MutableTags;
+}
+
+void UHelltechGameplayAbility::ApplyCooldown(const FGameplayAbilitySpecHandle Handle,
+                                             const FGameplayAbilityActorInfo* ActorInfo,
+                                             const FGameplayAbilityActivationInfo ActivationInfo) const
+{
+	// Do not call Super::ApplyCooldown(), this should fully replace it.
+
+	if (const UGameplayEffect* CooldownGameplayEffect = GetCooldownGameplayEffect())
+	{
+		const FGameplayEffectSpecHandle SpecHandle = MakeOutgoingGameplayEffectSpec(
+			CooldownGameplayEffect->GetClass(), GetAbilityLevel());
+
+		SpecHandle.Data.Get()->DynamicGrantedTags.AppendTags(CooldownTags);
+		SpecHandle.Data.Get()->SetSetByCallerMagnitude(FGameplayTag::RequestGameplayTag(FName("Data.Cooldown")),
+		                                               CooldownDuration.GetValueAtLevel(GetAbilityLevel()));
+
+		ApplyGameplayEffectSpecToOwner(Handle, ActorInfo, ActivationInfo, SpecHandle);
+	}
+}

--- a/Helltech/Source/Helltech/Abilities/HelltechGameplayAbility.h
+++ b/Helltech/Source/Helltech/Abilities/HelltechGameplayAbility.h
@@ -1,0 +1,38 @@
+#pragma once
+
+#include "CoreMinimal.h"
+#include "Abilities/GameplayAbility.h"
+#include "HelltechGameplayAbility.generated.h"
+
+enum class ELilithAbilityID : uint8;
+
+/**
+ * Base Gameplay Ability Class.
+ * Holds IDs to map abilities in the Gameplay Ability System can be extended to hold other related core information.
+ * Inherit from this class to create new Gameplay Abilities.
+ */
+UCLASS()
+class HELLTECH_API UHelltechGameplayAbility : public UGameplayAbility
+{
+	GENERATED_BODY()
+
+public:
+	UHelltechGameplayAbility();
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Ability")
+	ELilithAbilityID AbilityID;
+
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Cooldown")
+	FScalableFloat CooldownDuration;
+
+	// Add tags for each of the abilities' CooldownTags through their corresponding blueprint editors.
+	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "Cooldown")
+	FGameplayTagContainer CooldownTags;
+
+	FGameplayTagContainer TempCooldownTags;
+
+	virtual const FGameplayTagContainer* GetCooldownTags() const override;
+
+	virtual void ApplyCooldown(const FGameplayAbilitySpecHandle Handle, const FGameplayAbilityActorInfo* ActorInfo,
+	                           const FGameplayAbilityActivationInfo ActivationInfo) const override;
+};

--- a/Helltech/Source/Helltech/Helltech.Build.cs
+++ b/Helltech/Source/Helltech/Helltech.Build.cs
@@ -7,14 +7,33 @@ public class Helltech : ModuleRules
 	public Helltech(ReadOnlyTargetRules Target) : base(Target)
 	{
 		PCHUsage = PCHUsageMode.UseExplicitOrSharedPCHs;
-	
-		PublicDependencyModuleNames.AddRange(new string[] { "Core", "CoreUObject", "Engine", "InputCore", "EnhancedInput" });
 
-		PrivateDependencyModuleNames.AddRange(new string[] {  });
+		PublicDependencyModuleNames.AddRange(new string[]
+		{
+			"Core",
+			"CoreUObject",
+			"Engine",
+			"EnhancedInput",
+			"InputCore"
+		});
+
+		PrivateDependencyModuleNames.AddRange(new string[]
+		{
+			"GameplayAbilities",
+			"GameplayTags",
+			"GameplayTasks",
+			"Niagara",
+			"NiagaraCore"
+		});
+
+		PublicIncludePaths.AddRange(new[]
+		{
+			"Helltech"
+		});
 
 		// Uncomment if you are using Slate UI
 		// PrivateDependencyModuleNames.AddRange(new string[] { "Slate", "SlateCore" });
-		
+
 		// Uncomment if you are using online features
 		// PrivateDependencyModuleNames.Add("OnlineSubsystem");
 

--- a/Helltech/Source/Helltech/Helltech.cpp
+++ b/Helltech/Source/Helltech/Helltech.cpp
@@ -1,6 +1,4 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #include "Helltech.h"
 #include "Modules/ModuleManager.h"
 
-IMPLEMENT_PRIMARY_GAME_MODULE( FDefaultGameModuleImpl, Helltech, "Helltech" );
+IMPLEMENT_PRIMARY_GAME_MODULE(FDefaultGameModuleImpl, Helltech, "Helltech");

--- a/Helltech/Source/Helltech/Helltech.h
+++ b/Helltech/Source/Helltech/Helltech.h
@@ -1,6 +1,10 @@
-// Copyright Epic Games, Inc. All Rights Reserved.
-
 #pragma once
 
 #include "CoreMinimal.h"
 
+UENUM(BlueprintType)
+enum class ELilithAbilityID : uint8
+{
+	// 0 None
+	None UMETA(DisplayName = "None")
+};


### PR DESCRIPTION
Siguiendo lo hecho en Lilith, que a su vez se basó en la documentación de Tranek, he hecho override a las clases base del GAS, `UAbilitySystemComponent` `UGameplayAbility` y `UAttributeSet`.
See: https://github.com/tranek/GASDocumentation

Además, he añadido algo de código que creo que será útil durante el desarrollo:
- Manejo de cooldown por un set by caller. See: https://github.com/tranek/GASDocumentation?tab=readme-ov-file#concepts-ge-mods
- Funciones para saltarnos la parte de replicación cuando lancemos gameplay cues.
- Un breve ejemplo de cómo crear un atributo.

Por último, he creado el enumerado que usaremos para identificar a las distintas Gameplay Abilities, así como añadido la palabra Helltech al diccionario de Rider para que no se queje, ya que creo que saldrá mucho :)